### PR TITLE
Remove useless replacement in conftest.sh

### DIFF
--- a/nvidia-driver-G06.spec
+++ b/nvidia-driver-G06.spec
@@ -209,7 +209,6 @@ pushd %_sourcedir
 ln -sv %pci_id_file pci_ids-%{version}_k%{kbuildver}
 popd
 mkdir obj
-sed -i -e 's,-o "$ARCH" = "x86_64",-o "$ARCH" = "x86_64" -o "$ARCH" = "x86" -o "$ARCH" = "aarch64",' source/*/conftest.sh
 
 %build
 echo "*** sle_version: 0%{?sle_version} ***"


### PR DESCRIPTION
Not sure exactly what you are trying to accomplish here:
```
    if [ "$ARCH" = "i386" -o "$ARCH" = "x86_64" ]; then
        if [ -d "$SOURCES/arch/x86" ]; then
            KERNEL_ARCH="x86"
        fi
    fi
```
In your idea this should make the test x86 test run on all architectures?