### PR TITLE
Drop bundled libOpenCL and alternatives

### DIFF
--- a/nvidia-driver-G06.spec
+++ b/nvidia-driver-G06.spec
@@ -74,7 +74,6 @@ BuildRequires:  kernel-syms-azure
 %endif
 BuildRequires:  %kernel_module_package_buildreqs
 BuildRequires:  module-init-tools
-BuildRequires:  update-alternatives
 BuildRequires:  pciutils
 BuildRequires:  perl-Bootloader
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
The generic `libOpenCL.so.1` library is just fine, this is shipped in the driver run file only if the target system does not have it.