### PR TITLE
Add systemd preset, adjust documentation

### DIFF
--- a/50-nvidia.conf.modprobe
+++ b/50-nvidia.conf.modprobe
@@ -23,7 +23,7 @@ options nvidia NVreg_DeviceFileGID=33
 options nvidia NVreg_DeviceFileMode=0660
 
 # Enable complete power management. From:
-# file:///usr/share/doc/nvidia-driver/html/powermanagement.html
+# file:///usr/share/doc/packages/nvidia-common-G06/html/powermanagement.html
 
 options nvidia NVreg_DynamicPowerManagement=0x02
 options nvidia NVreg_EnableS0ixPowerManagement=1

--- a/70-nvidia-compute-G06.preset
+++ b/70-nvidia-compute-G06.preset
@@ -1,0 +1,4 @@
+# Enable persistence state. From:
+# file:///usr/share/doc/packages/nvidia-common-G06/html/nvidia-persistenced.html
+
+enable nvidia-persistenced.service

--- a/70-nvidia-video-G06.preset
+++ b/70-nvidia-video-G06.preset
@@ -1,0 +1,11 @@
+# Enable complete power management. From:
+# file:///usr/share/doc/packages/nvidia-common-G06/html/powermanagement.html
+
+enable nvidia-hibernate.service
+enable nvidia-resume.service
+enable nvidia-suspend.service
+
+# Enable Dynamic Boost. From:
+# file:///usr/share/doc/packages/nvidia-common-G06/html/dynamicboost.html
+
+enable nvidia-powerd.service


### PR DESCRIPTION
Drop the commands/scriptlets to add the `systemd` units for power management and instead ship presets for enabling all the required `systemd` units.

`70-nvidia-video-G06.preset` contained in `nvidia-video-G06` starts all the power management related `systemd` units.

`70-nvidia-compute-G06.preset` contained in `nvidia-compute-G06` starts the `nvidia-persistenced` daemon by default if installed (it always is).

Fix the documentation path (I used the Red Hat path in the previous MR) and move the HTML documentation to `nvidia-common-G06`, since it's related to both desktop and compute cases and `nvidia-common-G06` is always installed.