### PR TITLE
Make SPEC file a bit more readable

### DIFF
--- a/nvidia-driver-G06.spec
+++ b/nvidia-driver-G06.spec
@@ -24,12 +24,9 @@
 #
 %global __requires_exclude kernel-uname-r*
 
-# nvidia still builds all packages on sle15sp0, but let's assume packages are used on sle15sp4 and later
-%define nvidia_build 0
-
 %define req_random_kernel_sources 0
 
-%if (0%{?nvidia_build} ||  0%{?suse_version} > 1600)
+%if 0%{?suse_version} > 1600
 %define req_random_kernel_sources 1
 %endif
 
@@ -143,7 +140,7 @@ exit $RES' %_builddir/nvidia-kmp-template)
 %kernel_module_package %kmp_template %_builddir/nvidia-kmp-template -p %_sourcedir/preamble -f %_sourcedir/%kmp_filelist -x %x_flavors
 
 # supplements no longer depend on the driver
-%if (0%{?nvidia_build} || 0%{?sle_version} >= 150400 || 0%{?suse_version} >= 1550)
+%if (0%{?sle_version} >= 150400 || 0%{?suse_version} >= 1550)
 %define pci_id_file %_sourcedir/pci_ids-%version
 %else
 %define pci_id_file %_sourcedir/pci_ids-%version.new


### PR DESCRIPTION
- Drop `nvidia_build`, I've finally convinced product management to not support anything that is already EOL by the vendors, so we also build on SLE 15sp5 / Leap 15.5.
- Move the creation of the folders at the top of the `%install` section closer to the various topics, this drops also creation of the `/usr/lib` folders on `aarch64`.
- Drop creation of unused `/usr/share/application/pixmaps` (leftover from the removal of `nvidia-settings`).
- `nvidia-common-G06` is actually a `noarch` package.