### PR TITLE
Update power management configuration

### DIFF
--- a/50-nvidia.conf.modprobe
+++ b/50-nvidia.conf.modprobe
@@ -25,6 +25,6 @@ options nvidia NVreg_DeviceFileMode=0660
 # Enable complete power management. From:
 # file:///usr/share/doc/packages/nvidia-common-G06/html/powermanagement.html
 
-options nvidia NVreg_DynamicPowerManagement=0x02
+options nvidia NVreg_TemporaryFilePath=/var/tmp
 options nvidia NVreg_EnableS0ixPowerManagement=1
 options nvidia NVreg_PreserveVideoMemoryAllocations=1


### PR DESCRIPTION
- Do not force D3 sleep state (power down) on pre-Ampere GPUs
- Allow saving the GPU memory to /var/tmp