### PR TITLE
disable powerd service by default

### DIFF
--- a/70-nvidia-video-G06.preset
+++ b/70-nvidia-video-G06.preset
@@ -5,7 +5,7 @@ enable nvidia-hibernate.service
 enable nvidia-resume.service
 enable nvidia-suspend.service
 
-# Enable Dynamic Boost. From:
+# Disable Dynamic Boost. From:
 # file:///usr/share/doc/packages/nvidia-common-G06/html/dynamicboost.html
 
-enable nvidia-powerd.service
+disable nvidia-powerd.service


### PR DESCRIPTION
We cannot assume, that each machine is a laptop. Therefore don't enable powerd by default. Partners are complaining their tests are failing because of this.

https://bugzilla.suse.com/show_bug.cgi?id=1234062 (hidden SLE bug)

@scaronni-nvidia I think we discusses this before, but I forgot about the outcome. :-( Mabye there is a more intelligent solution, e.g. trying to detect for a laptop form factor and only enable then.