### PR TITLE
Fix issue when switching module implementation

### DIFF
--- a/kmp-postun.sh
+++ b/kmp-postun.sh
@@ -1,15 +1,15 @@
 flavor=%1
 if [ "$1" = 0 ] ; then
-	# get rid of *all* nvidia kernel modules when uninstalling package (boo#1180010)
-	for dir in $(find /lib/modules  -mindepth 1 -maxdepth 1 -type d); do
-                test -d $dir/updates && rm -f  $dir/updates/nvidia*.ko
-                # generate modules.dep, etc. to avoid dracut failures
-                # later (boo#1213765)
-                if [ -d $dir/kernel ]; then
-                        kversion=$(basename $dir)
-                        depmod $kversion
-                fi
-	done
+  # get rid of *all* nvidia kernel modules when uninstalling package (boo#1180010)
+  # Don't do it if there is still an nvidia kmp package installed, or we end up
+  # removing the freshly built modules from the other package (ex. switching between
+  # open and closed modules).
+  rpm -qa nvidia-open-driver-G06-kmp\* | grep -q nvidia-open-driver-G06-kmp
+  if [ $? -eq 1 ]; then
+      for dir in $(find /lib/modules  -mindepth 1 -maxdepth 1 -type d -name "*-${flavor}"); do
+          test -d $dir/updates && rm -f $dir/updates/nvidia*.ko
+      done
+  fi
   # cleanup of bnc# 1000625
   rm -f /usr/lib/tmpfiles.d/nvidia-logind-acl-trick-G06.conf
 fi


### PR DESCRIPTION
When switching module implementation (open/proprietary), the modules installed by the second implementation are wiped out when the `%postun` section of the former implementation runs.

Example:

```
zypper install nvidia-open-driver-G06-kmp
zypper install --force nvidia-driver-G06-kmp
```

After the successful installation of `nvidia-driver-G06-kmp`, `nvidia-open-driver-G06-kmp` gets removed and *then* the `%postun` runs as the package is no longer installed, wiping out the modules installed by `nvidia-driver-G06-kmp`.

Unfortunately, we need to query the open driver in the proprietary one and viceversa, as at the time of the `%postun` run the package still appear. We can't also use a wildcard (ex. `rpm -q --quiet nvidia-driver-G06-kmp\*` to catch all KMP variants) as `rpm -q` would return 0 anyway on the negative but successful query.

I think it's really ugly but I couldn't think of anything better and simpler.