### PR TITLE
Run udev rule only on add/bind

### DIFF
--- a/60-nvidia.rules
+++ b/60-nvidia.rules
@@ -3,7 +3,7 @@
 # In case the DDX is not started, the device nodes are never created, so call
 # nvidia-modprobe in the udev rules to cover the Wayland/EGLStream and compute
 # case without a started display.
-KERNEL=="nvidia", RUN+="/usr/bin/nvidia-modprobe", TAG+="uaccess"
+ACTION=="add|bind", KERNEL=="nvidia", RUN+="/usr/bin/nvidia-modprobe", TAG+="uaccess"
 
 # Enable runtime PM for NVIDIA VGA/3D controller devices on driver bind
 ACTION=="bind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030000", TEST=="power/control", ATTR{power/control}="auto"


### PR DESCRIPTION
Run the `udev` rule that calls `nvidia-modprobe` only when loading a kernel module.

This prevents an issue with compute nodes without modesetting enabled (so the modules can be unloaded) that prevents users from unloading the modules to make changes (NVSwitch, NVReg changes., filtering out GPUs, etc.). In case of a module unload, the module would get immediately reloaded because of the rule.

This prevents the rule from running at every single change, for example during an unload.