### PR TITLE
moved alternate-install-present from nvidia-common-G06 to KMP

### DIFF
--- a/kmp-filelist
+++ b/kmp-filelist
@@ -8,3 +8,6 @@
 /usr/src/kernel-modules/nvidia-%{-v*}-%1
 %ghost %attr(755,root,root) %dir /usr/share/nvidia-pubkeys
 %ghost %attr(644,root,root) /usr/share/nvidia-pubkeys/MOK-%{name}-%{-v*}-%1.der
+%dir %{_prefix}/lib/nvidia
+%{_prefix}/lib/nvidia/alternate-install-present
+

--- a/nvidia-driver-G06.spec
+++ b/nvidia-driver-G06.spec
@@ -53,6 +53,7 @@ Source18:       kmp-postun.sh
 Source22:       kmp-trigger.sh
 Source25:       %{name}.rpmlintrc
 Source26:       json-to-pci-id-list.py
+Source27:       alternate-install-present
 Patch0:         objtool-fix.patch
 NoSource:       0
 NoSource:       1
@@ -241,4 +242,5 @@ for flavor in %flavors_to_build; do
     fi
 %endif
 done
+install -p -m 644 -D %{SOURCE27} %{buildroot}%{_prefix}/lib/nvidia/alternate-install-present
 %changelog

--- a/nvidia-video-G06.spec
+++ b/nvidia-video-G06.spec
@@ -47,7 +47,6 @@ Source10:       50-nvidia.conf.modprobe
 Source11:       60-nvidia.conf.dracut
 Source12:       70-nvidia-video-G06.preset
 Source13:       70-nvidia-compute-G06.preset
-Source16:       alternate-install-present
 NoSource:       0
 NoSource:       1
 NoSource:       4
@@ -415,7 +414,6 @@ ln -snf ../libnvidia-allocator.so.1 %{buildroot}%{_prefix}/lib/gbm/nvidia-drm_gb
 
 # Common files
 install -p -m 644 -D %{SOURCE9} %{buildroot}%{_udevrulesdir}/60-nvidia.rules
-install -p -m 644 -D %{SOURCE16} %{buildroot}%{_prefix}/lib/nvidia/alternate-install-present
 install -d %{buildroot}%{_firmwaredir}/nvidia/%{version}
 install -m 644 firmware/* %{buildroot}%{_firmwaredir}/nvidia/%{version}/
 
@@ -632,7 +630,6 @@ fi
 %{_firmwaredir}/nvidia/%{version}/gsp_ga10x.bin
 %{_firmwaredir}/nvidia/%{version}/gsp_tu10x.bin
 %dir %{_prefix}/lib/nvidia
-%{_prefix}/lib/nvidia/alternate-install-present
 %{_udevrulesdir}/60-nvidia.rules
 %if 0%{?suse_version} >= 1550
 %dir %{_prefix}/lib/dracut


### PR DESCRIPTION
This is to prevent customers using the nvidia-installer when only the KMP has been installed. This can easily happen when the open driver KMP has been installed automatically without any other driver RPMs. So I decided to also add such a file to the open driver KMP. To prevent file conflicts between nvdia-common-G06 and the open driver KMP I moved this file now also to the proprietary KMP. The KMPs for prroprietary and open driver conflict anyway.