### PR TITLE
revert ea2c415 : moved alternate-install-present from nvidia-common-G…

### DIFF
--- a/kmp-filelist
+++ b/kmp-filelist
@@ -8,6 +8,3 @@
 /usr/src/kernel-modules/nvidia-%{-v*}-%1
 %ghost %attr(755,root,root) %dir /usr/share/nvidia-pubkeys
 %ghost %attr(644,root,root) /usr/share/nvidia-pubkeys/MOK-%{name}-%{-v*}-%1.der
-%dir %{_prefix}/lib/nvidia
-%{_prefix}/lib/nvidia/alternate-install-present
-

--- a/nvidia-driver-G06.spec
+++ b/nvidia-driver-G06.spec
@@ -53,7 +53,6 @@ Source18:       kmp-postun.sh
 Source22:       kmp-trigger.sh
 Source25:       %{name}.rpmlintrc
 Source26:       json-to-pci-id-list.py
-Source27:       alternate-install-present
 Patch0:         objtool-fix.patch
 NoSource:       0
 NoSource:       1
@@ -242,5 +241,4 @@ for flavor in %flavors_to_build; do
     fi
 %endif
 done
-install -p -m 644 -D %{SOURCE27} %{buildroot}%{_prefix}/lib/nvidia/alternate-install-present
 %changelog

--- a/nvidia-video-G06.spec
+++ b/nvidia-video-G06.spec
@@ -47,6 +47,7 @@ Source10:       50-nvidia.conf.modprobe
 Source11:       60-nvidia.conf.dracut
 Source12:       70-nvidia-video-G06.preset
 Source13:       70-nvidia-compute-G06.preset
+Source16:       alternate-install-present
 NoSource:       0
 NoSource:       1
 NoSource:       4
@@ -414,6 +415,7 @@ ln -snf ../libnvidia-allocator.so.1 %{buildroot}%{_prefix}/lib/gbm/nvidia-drm_gb
 
 # Common files
 install -p -m 644 -D %{SOURCE9} %{buildroot}%{_udevrulesdir}/60-nvidia.rules
+install -p -m 644 -D %{SOURCE16} %{buildroot}%{_prefix}/lib/nvidia/alternate-install-present
 install -d %{buildroot}%{_firmwaredir}/nvidia/%{version}
 install -m 644 firmware/* %{buildroot}%{_firmwaredir}/nvidia/%{version}/
 
@@ -630,6 +632,7 @@ fi
 %{_firmwaredir}/nvidia/%{version}/gsp_ga10x.bin
 %{_firmwaredir}/nvidia/%{version}/gsp_tu10x.bin
 %dir %{_prefix}/lib/nvidia
+%{_prefix}/lib/nvidia/alternate-install-present
 %{_udevrulesdir}/60-nvidia.rules
 %if 0%{?suse_version} >= 1550
 %dir %{_prefix}/lib/dracut


### PR DESCRIPTION
…06 to KMP

Doesn't work since this file conflicts between the flavors of the KMP which need to be installable at the same time.