### PR TITLE
improve Bourne shell compatibility in scripts

### DIFF
--- a/kmp-trigger.sh
+++ b/kmp-trigger.sh
@@ -111,10 +111,10 @@ EOF
 devid=-1
 for dev in $(ls -d /sys/bus/pci/devices/*); do
   vendorid=$(cat $dev/vendor)
-  if [ "$vendorid" == "0x10de" ]; then
+  if [ "$vendorid" = "0x10de" ]; then
     class=$(cat $dev/class)
     classid=${class%%00}
-    if [ "$classid" == "0x0300" -o "$classid" == "0x0302" ]; then
+    if [ "$classid" = "0x0300" -o "$classid" = "0x0302" ]; then
       devid=$((devid+1))
       ln -snf /dev/nvidia${devid} /run/udev/static_node-tags/uaccess/nvidia${devid}
       echo "L /run/udev/static_node-tags/uaccess/nvidia${devid} - - - - /dev/nvidia${devid}" >> /usr/lib/tmpfiles.d/nvidia-logind-acl-trick-G06.conf

--- a/nvidia-video-G06.spec
+++ b/nvidia-video-G06.spec
@@ -533,10 +533,10 @@ EOF
 devid=-1
 for dev in $(ls -d /sys/bus/pci/devices/*); do 
   vendorid=$(cat $dev/vendor)
-  if [ "$vendorid" == "0x10de" ]; then 
+  if [ "$vendorid" = "0x10de" ]; then
     class=$(cat $dev/class)
     classid=${class%%00}
-    if [ "$classid" == "0x0300" -o "$classid" == "0x0302" ]; then 
+    if [ "$classid" = "0x0300" -o "$classid" = "0x0302" ]; then
       devid=$((devid+1))
       ln -snf /dev/nvidia${devid} /run/udev/static_node-tags/uaccess/nvidia${devid}
       echo "L /run/udev/static_node-tags/uaccess/nvidia${devid} - - - - /dev/nvidia${devid}" >> /usr/lib/tmpfiles.d/nvidia-logind-acl-trick-G06.conf


### PR DESCRIPTION
Use '=' instead of '==' for comparing strings.