### PR TITLE
Mark services to be set to presets in %pre via %systemd_pre() ...

### DIFF
--- a/nvidia-video-G06.spec
+++ b/nvidia-video-G06.spec
@@ -422,6 +422,14 @@ install -m 0644 -p -D %{SOURCE11} %{buildroot}%{_sysconfdir}/dracut.conf.d/60-nv
 mkdir -p %{buildroot}%{_datadir}/nvidia/files.d
 install -m 0644 -p -D sandboxutils-filelist.json %{buildroot}%{_datadir}/nvidia/files.d/
 
+%pre
+# mark to be set to presets (boo#1240991, gh issue#51)
+%systemd_pre nvidia-hibernate.service
+%systemd_pre nvidia-powerd.service
+%systemd_pre nvidia-resume.service
+%systemd_pre nvidia-suspend.service
+%systemd_pre nvidia-suspend-then-hibernate.service
+
 %post
 /sbin/ldconfig
 # Bug #345125
@@ -431,18 +439,12 @@ if ls var/lib/hardware/ids/* > /dev/null 2<&1; then
     cat $i >> var/lib/hardware/hd.ids
   done
 fi
-# Preset the services to follow the system's policy
+# Preset the services if they are freshly installed (boo#1240991, gh issue#51)
 %systemd_post nvidia-hibernate.service
 %systemd_post nvidia-powerd.service
 %systemd_post nvidia-resume.service
 %systemd_post nvidia-suspend.service
 %systemd_post nvidia-suspend-then-hibernate.service
-# the official way above doesn't seem to work ;-(
-/usr/bin/systemctl preset nvidia-hibernate.service
-/usr/bin/systemctl preset nvidia-powerd.service
-/usr/bin/systemctl preset nvidia-resume.service
-/usr/bin/systemctl preset nvidia-suspend.service
-/usr/bin/systemctl preset nvidia-suspend-then-hibernate.service
 exit 0
 
 %preun
@@ -475,10 +477,9 @@ exit 0
 
 %post -n nvidia-compute-G06
 /sbin/ldconfig
-# Preset the service to follow the system's policy
+# Preset the service if it is freshly installed (boo#1240991, gh issue#51)
+# mark to be set to presets is done in %pre of nvidia-persistenced package
 %systemd_post nvidia-persistenced.service
-# the official way above doesn't seem to work ;-(
-/usr/bin/systemctl preset nvidia-persistenced.service || true
 exit 0
 
 %preun -n nvidia-compute-G06


### PR DESCRIPTION
... so this happens in %post if they are freshly installed and setting remains during a package update ([boo#1240991](https://bugzilla.suse.com/show_bug.cgi?id=1240991), gh issue# https://github.com/openSUSE/nvidia-driver-G06/issues/51)

Getting rid of hard presetting services in %post.

This requires also a change in nvidia-persistenced package.

--> https://build.opensuse.org/package/show/X11:XOrg/nvidia-persistenced

```
Index: nvidia-persistenced.changes
=================================================================== --- nvidia-persistenced.changes (revision 17)
+++ nvidia-persistenced.changes (revision 18)
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Apr  9 14:16:25 UTC 2025 - Stefan Dirsch <sndirsch@suse.com> +
+- mark systemd service to be set to presets in %pre
+  (boo#1240991, gh issue#51) +- get rid of %post, %preun and %postun; nvidia-compute-G06
+  already takes care of this +
+-------------------------------------------------------------------
 Sat Mar 15 02:10:42 UTC 2025 - Stefan Dirsch <sndirsch@suse.com>

 - update to version 570.133.07 (bsc#1239653) Index: nvidia-persistenced.spec
=================================================================== --- nvidia-persistenced.spec (revision 17)
+++ nvidia-persistenced.spec (revision 18)
@@ -85,17 +85,9 @@
 # Fix manpage permissions
 chmod 0644 %{buildroot}%{_mandir}/man1/%{name}.1

-%pre -f %{name}.pre
-%service_add_pre %{name}.service
-
-%post
-%service_add_post %{name}.service
-
-%preun
-%service_del_preun %{name}.service
-
-%postun
-%service_del_postun %{name}.service
+%pre
+# mark to be set to presets (boo#1240991, gh issue#51) 
+%systemd_pre nvidia-persistenced.service

 %files
 %license COPYING
```