### PR TITLE
dracut config: removed not longer used 'nvidia_peermem' module (boo#1241114)

### DIFF
--- a/60-nvidia.conf.dracut
+++ b/60-nvidia.conf.dracut
@@ -1,1 +1,1 @@
-omit_drivers+=" nvidia nvidia_drm nvidia_modeset nvidia_peermem nvidia_uvm "
+omit_drivers+=" nvidia nvidia_drm nvidia_modeset nvidia_uvm "


### PR DESCRIPTION
Avoid dracut error message about non-existing 'nvidia_peermem' when users add drivers to initrd.

For more details see https://bugzilla.suse.com/show_bug.cgi?id=1241114#c5