### PR TITLE
nvidia-common-G06: no longer require/suggest any driver

### DIFF
--- a/nvidia-video-G06.spec
+++ b/nvidia-video-G06.spec
@@ -143,13 +143,7 @@ Group:          System/Libraries
 Provides:       kernel-firmware-nvidia-gspx-G06 = %{version}
 Obsoletes:      kernel-firmware-nvidia-gspx-G06 < %{version}
 Requires:       nvidia-modprobe >= %{version}
-Requires:       (nvidia-driver-G06-kmp = %{version} or nvidia-open-driver-G06-kmp = %{version} or nvidia-open-driver-G06-signed-kmp = %{version})
-# prefer the opengpu driver; resolver works alphabetically and would suggest
-# proprietary driver instead; use Suggests instead of Recommends since it's
-# common to install with --no-recommends to have a minimal installation for
-# compute nodes ...
 Requires(post): perl-Bootloader
-Suggests:       nvidia-open-driver-G06-signed-kmp = %{version}
 
 %description -n nvidia-common-G06
 Common files for NVIDIA driver installations.


### PR DESCRIPTION
... neither proprietary nor open driver, since it will end up in chosing proprietary driver when installing with --no-recommends (due to the alphabetic order and suggests being ignored also when using --norecommends); instead hardware Supplements (PCI IDs) need to be used, which is possible by adding meta packages with these Supplements to the NVIDIA driver repository, which then require the correct driver with the appropriate version (bsc#1244042)